### PR TITLE
ci: enable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: 'gomod'
+    directory: '/'
+    schedule:
+        interval: 'weekly'
+    groups:
+        production-dependencies:
+            dependency-type: 'production'
+        development-dependencies:
+            dependency-type: 'development'


### PR DESCRIPTION
Dependabot could be enabled for this repository. Please enable it by merging this pull request so that we can keep our dependencies up to date and secure.